### PR TITLE
feature/set-default-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ _Set the value of an attribute by name. Creates the attribute if it does not alr
   - `value` (Any): Value to set for the attribute.
 - **Return Type**: `None`
 
+**‍‍‍`g.set_default(name, value)`**
+_Set the default value of an attribute by name. If the attribute already exists, the existing value is not overwritten._
+
+- **Parameters**:
+  - `name` (str): Name of the attribute to set a default value for.
+  - `value` (Any): Default value to set if the attribute does not already exist.
+- **Return Type**: `None`
+
 
 ## Example
 

--- a/fastapi_g_context/fastapi_g.py
+++ b/fastapi_g_context/fastapi_g.py
@@ -65,7 +65,7 @@ class Globals:
         """
         self.__setattr__(name, value)
 
-    def get(self, name: str, default: Any = None) -> Any:
+    def get(self, name: str, default: Optional[Any] = None) -> Any:
         """
         Retrieve the value of a variable with an optional default value.
 
@@ -81,7 +81,7 @@ class Globals:
 
         return default
 
-    def pop(self, name: str, default: Any = None) -> Any:
+    def pop(self, name: str, default: Optional[Any] = None) -> Any:
         """
         Retrieve and remove the value of a variable, with an optional default.
 

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -65,3 +65,9 @@ def test_to_dict():
     g.key1 = "value1"
     g.key2 = "value2"
     assert g.to_dict() == {"key1": "value1", "key2": "value2"}
+
+
+def test_set_default():
+    g.set_default("key1", "value1")
+    g.set_default("key2", "value2")
+    assert g.to_dict() == {"key1": "value1", "key2": "value2"}


### PR DESCRIPTION
This PR adds a set_default method to the Globals class. This method sets a default value for an attribute only if it doesn't already exist, preserving any existing value.

Key Changes:
- New method: set_default(name: str, value: Any) -> None
- Adds flexibility by allowing default value assignment without overwriting existing data.
- Includes unit tests for the new functionality.

Usage Example:

```python
g.set_default('default_key1', 'default_value1') 
# Or
app = FastAPI()
app.add_middleware(
    GlobalsMiddleware, 
    g_default_values={"default_key1": "default_value1"},
)
```